### PR TITLE
Upcoming breaking changes in 3.1 canary 6 onwards.

### DIFF
--- a/app/src/main/java/com/github/nitrico/lastadapter_sample/ui/KotlinListFragment.kt
+++ b/app/src/main/java/com/github/nitrico/lastadapter_sample/ui/KotlinListFragment.kt
@@ -13,39 +13,39 @@ import com.github.nitrico.lastadapter_sample.databinding.*
 class KotlinListFragment : ListFragment() {
 
     private val typeHeader = Type<ItemHeaderBinding>(R.layout.item_header)
-            .onCreate { println("Created ${it.binding.item} at #${it.adapterPosition}") }
-            .onBind { println("Bound ${it.binding.item} at #${it.adapterPosition}") }
-            .onRecycle { println("Recycled ${it.binding.item} at #${it.adapterPosition}") }
-            .onClick { activity.toast("Clicked #${it.adapterPosition}: ${it.binding.item}") }
-            .onLongClick { activity.toast("Long-clicked #${it.adapterPosition}: ${it.binding.item}") }
+            .onCreate { println("Created ${it.binding?.item} at #${it.adapterPosition}") }
+            .onBind { println("Bound ${it.binding?.item} at #${it.adapterPosition}") }
+            .onRecycle { println("Recycled ${it.binding?.item} at #${it.adapterPosition}") }
+            .onClick { activity.toast("Clicked #${it.adapterPosition}: ${it.binding?.item}") }
+            .onLongClick { activity.toast("Long-clicked #${it.adapterPosition}: ${it.binding?.item}") }
 
     private val typeHeaderFirst = Type<ItemHeaderFirstBinding>(R.layout.item_header_first)
-            .onCreate { println("Created ${it.binding.item} at #${it.adapterPosition}") }
-            .onBind { println("Bound ${it.binding.item} at #${it.adapterPosition}") }
-            .onRecycle { println("Recycled ${it.binding.item} at #${it.adapterPosition}") }
-            .onClick { activity.toast("Clicked #${it.adapterPosition}: ${it.binding.item}") }
-            .onLongClick { activity.toast("Long-clicked #${it.adapterPosition}: ${it.binding.item}") }
+            .onCreate { println("Created ${it.binding?.item} at #${it.adapterPosition}") }
+            .onBind { println("Bound ${it.binding?.item} at #${it.adapterPosition}") }
+            .onRecycle { println("Recycled ${it.binding?.item} at #${it.adapterPosition}") }
+            .onClick { activity.toast("Clicked #${it.adapterPosition}: ${it.binding?.item}") }
+            .onLongClick { activity.toast("Long-clicked #${it.adapterPosition}: ${it.binding?.item}") }
 
     private val typePoint = Type<ItemPointBinding>(R.layout.item_point)
-            .onCreate { println("Created ${it.binding.item} at #${it.adapterPosition}") }
-            .onBind { println("Bound ${it.binding.item} at #${it.adapterPosition}") }
-            .onRecycle { println("Recycled ${it.binding.item} at #${it.adapterPosition}") }
-            .onClick { activity.toast("Clicked #${it.adapterPosition}: ${it.binding.item}") }
-            .onLongClick { activity.toast("Long-clicked #${it.adapterPosition}: ${it.binding.item}") }
+            .onCreate { println("Created ${it.binding?.item} at #${it.adapterPosition}") }
+            .onBind { println("Bound ${it.binding?.item} at #${it.adapterPosition}") }
+            .onRecycle { println("Recycled ${it.binding?.item} at #${it.adapterPosition}") }
+            .onClick { activity.toast("Clicked #${it.adapterPosition}: ${it.binding?.item}") }
+            .onLongClick { activity.toast("Long-clicked #${it.adapterPosition}: ${it.binding?.item}") }
 
     private val typeCar = Type<ItemCarBinding>(R.layout.item_car)
-            .onCreate { println("Created ${it.binding.item} at #${it.adapterPosition}") }
-            .onBind { println("Bound ${it.binding.item} at #${it.adapterPosition}") }
-            .onRecycle { println("Recycled ${it.binding.item} at #${it.adapterPosition}") }
-            .onClick { activity.toast("Clicked #${it.adapterPosition}: ${it.binding.item}") }
-            .onLongClick { activity.toast("Long-clicked #${it.adapterPosition}: ${it.binding.item}") }
+            .onCreate { println("Created ${it.binding?.item} at #${it.adapterPosition}") }
+            .onBind { println("Bound ${it.binding?.item} at #${it.adapterPosition}") }
+            .onRecycle { println("Recycled ${it.binding?.item} at #${it.adapterPosition}") }
+            .onClick { activity.toast("Clicked #${it.adapterPosition}: ${it.binding?.item}") }
+            .onLongClick { activity.toast("Long-clicked #${it.adapterPosition}: ${it.binding?.item}") }
 
     private val typePerson = Type<ItemPersonBinding>(R.layout.item_person)
-            .onCreate { println("Created ${it.binding.item} at #${it.adapterPosition}") }
-            .onBind { println("Bound ${it.binding.item} at #${it.adapterPosition}") }
-            .onBind { println("Recycled ${it.binding.item} at #${it.adapterPosition}") }
-            .onClick { activity.toast("Clicked #${it.adapterPosition}: ${it.binding.item}") }
-            .onLongClick { activity.toast("Long-clicked #${it.adapterPosition}: ${it.binding.item}") }
+            .onCreate { println("Created ${it.binding?.item} at #${it.adapterPosition}") }
+            .onBind { println("Bound ${it.binding?.item} at #${it.adapterPosition}") }
+            .onBind { println("Recycled ${it.binding?.item} at #${it.adapterPosition}") }
+            .onClick { activity.toast("Clicked #${it.adapterPosition}: ${it.binding?.item}") }
+            .onLongClick { activity.toast("Long-clicked #${it.adapterPosition}: ${it.binding?.item}") }
 
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
@@ -73,18 +73,18 @@ class KotlinListFragment : ListFragment() {
                 .map<Header, ItemHeaderBinding>(R.layout.item_header)
                 .map<Point>(typePoint)
                 .map<Car>(Type<ItemCarBinding>(R.layout.item_car)
-                        .onCreate { println("Created ${it.binding.item} at #${it.adapterPosition}") }
-                        .onBind { println("Bound ${it.binding.item} at #${it.adapterPosition}") }
-                        .onRecycle { println("Recycled ${it.binding.item} at #${it.adapterPosition}") }
-                        .onClick { activity.toast("Clicked #${it.adapterPosition}: ${it.binding.item}") }
-                        .onLongClick { activity.toast("Long-clicked #${it.adapterPosition}: ${it.binding.item}") }
+                        .onCreate { println("Created ${it.binding?.item} at #${it.adapterPosition}") }
+                        .onBind { println("Bound ${it.binding?.item} at #${it.adapterPosition}") }
+                        .onRecycle { println("Recycled ${it.binding?.item} at #${it.adapterPosition}") }
+                        .onClick { activity.toast("Clicked #${it.adapterPosition}: ${it.binding?.item}") }
+                        .onLongClick { activity.toast("Long-clicked #${it.adapterPosition}: ${it.binding?.item}") }
                 )
                 .map<Person, ItemPersonBinding>(R.layout.item_person) {
-                    onCreate { println("Created ${it.binding.item} at #${it.adapterPosition}") }
-                    onBind { println("Bound ${it.binding.item} at #${it.adapterPosition}") }
-                    onRecycle { println("Recycled ${it.binding.item} at #${it.adapterPosition}") }
-                    onClick { activity.toast("Clicked #${it.adapterPosition}: ${it.binding.item}") }
-                    onLongClick { activity.toast("Long-clicked #${it.adapterPosition}: ${it.binding.item}") }
+                    onCreate { println("Created ${it.binding?.item} at #${it.adapterPosition}") }
+                    onBind { println("Bound ${it.binding?.item} at #${it.adapterPosition}") }
+                    onRecycle { println("Recycled ${it.binding?.item} at #${it.adapterPosition}") }
+                    onClick { activity.toast("Clicked #${it.adapterPosition}: ${it.binding?.item}") }
+                    onLongClick { activity.toast("Long-clicked #${it.adapterPosition}: ${it.binding?.item}") }
                 }
                 .into(list)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,8 @@ buildscript {
             sdkMin : 14,
             sdkTarget : 27,
             buildTools : '27.0.1',
-            gradlePlugin : '3.0.1',
-            kotlin : '1.2.0',
+            gradlePlugin : '3.1.0-alpha06',
+            kotlin : '1.2.10',
             support : '27.0.2'
     ]
     repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,3 +18,4 @@
 # org.gradle.parallel=true
 
 org.gradle.jvmargs=-Xmx2048m
+android.databinding.enableV2=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.3.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/lastadapter/build.gradle
+++ b/lastadapter/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
+    id 'kotlin-kapt'
 }
 
 android {
@@ -10,7 +11,18 @@ android {
     dataBinding.enabled true
 }
 
+afterEvaluate {
+    android.libraryVariants.all {
+        def name = it.name.capitalize()
+        tasks["kapt${name}Kotlin"].dependsOn("transformDataBindingWithDataBindingMergeArtifactsFor${name}")
+
+    }
+}
+
+
 dependencies {
+    //Data binding
+    kapt "com.android.databinding:compiler:$versions.gradlePlugin"
     compile "com.android.support:recyclerview-v7:$versions.support"
     compile "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlin"
 }

--- a/lastadapter/src/main/java/com/github/nitrico/lastadapter/Holder.kt
+++ b/lastadapter/src/main/java/com/github/nitrico/lastadapter/Holder.kt
@@ -19,6 +19,6 @@ package com.github.nitrico.lastadapter
 import android.databinding.ViewDataBinding
 import android.support.v7.widget.RecyclerView
 
-open class Holder<B : ViewDataBinding>(val binding: B) : RecyclerView.ViewHolder(binding.root) {
+open class Holder<B : ViewDataBinding>(val binding: B?) : RecyclerView.ViewHolder(binding?.root) {
     internal var created = false
 }

--- a/lastadapter/src/main/java/com/github/nitrico/lastadapter/LastAdapter.kt
+++ b/lastadapter/src/main/java/com/github/nitrico/lastadapter/LastAdapter.kt
@@ -35,7 +35,7 @@ class LastAdapter(private val list: List<Any>,
     private val DATA_INVALIDATION = Any()
     private val callback = ObservableListCallback(this)
     private var recyclerView: RecyclerView? = null
-    private var inflater: LayoutInflater? = null
+    private lateinit var inflater: LayoutInflater
 
     private val map = mutableMapOf<Class<*>, BaseType>()
     private var layoutHandler: LayoutHandler? = null
@@ -90,7 +90,7 @@ class LastAdapter(private val list: List<Any>,
     override fun onCreateViewHolder(view: ViewGroup, viewType: Int): Holder<ViewDataBinding> {
         val binding = DataBindingUtil.inflate<ViewDataBinding>(inflater, viewType, view, false)
         val holder = Holder(binding)
-        binding.addOnRebindCallback(object : OnRebindCallback<ViewDataBinding>() {
+        binding?.addOnRebindCallback(object : OnRebindCallback<ViewDataBinding>() {
             override fun onPreBind(binding: ViewDataBinding) = recyclerView?.isComputingLayout ?: false
             override fun onCanceled(binding: ViewDataBinding) {
                 if (recyclerView?.isComputingLayout ?: true) {
@@ -107,8 +107,8 @@ class LastAdapter(private val list: List<Any>,
 
     override fun onBindViewHolder(holder: Holder<ViewDataBinding>, position: Int) {
         val type = getType(position)!!
-        holder.binding.setVariable(getVariable(type), list[position])
-        holder.binding.executePendingBindings()
+        holder.binding?.setVariable(getVariable(type), list[position])
+        holder.binding?.executePendingBindings()
         @Suppress("UNCHECKED_CAST")
         if (type is AbsType<*>) {
             if (!holder.created) {
@@ -120,7 +120,7 @@ class LastAdapter(private val list: List<Any>,
 
     override fun onBindViewHolder(holder: Holder<ViewDataBinding>, position: Int, payloads: List<Any>) {
         if (isForDataBinding(payloads)) {
-            holder.binding.executePendingBindings()
+            holder.binding?.executePendingBindings()
         } else {
             super.onBindViewHolder(holder, position, payloads)
         }


### PR DESCRIPTION
Android studio 3.1 Canary 6 introduces Databinding compiler which introduces new changes which are breaking for library consumers. As per [Release Notes](https://androidstudio.googleblog.com/2017/12/android-studio-31-canary-6-is-now.html) binding code is generated and packaged in AAR, and dependent modules are no longer re-generating library bindings. 

Also as per [documentation](https://developer.android.com/topic/libraries/data-binding/index.html#enable_v2) this changes are backward incompatible, means consumers of Databinding v2 can't use library  or code generated against Databinding v1. 

Another change as stated [here](https://issuetracker.google.com/issues/70908732#comment4) data binding inflation methods (`inflate` and `setContentView` etc...) will return nullable bindings (Null in case of layout is not binding layout). Which is breaking change for consumers.


This pull request facilitates both above stated changes, but I suggest be cautious as the changes are for alpha release of plugin. 